### PR TITLE
Add 'recovery' possibility to `DeviceType` and 'sideload-auto-reboot' option to `RebootType`

### DIFF
--- a/src/adb/command/host-transport/reboot.ts
+++ b/src/adb/command/host-transport/reboot.ts
@@ -1,6 +1,6 @@
 import Command from '../../command';
 
-export type RebootType = 'bootloader' | 'recovery' | 'sideload' | 'fastboot';
+export type RebootType = 'bootloader' | 'recovery' | 'sideload' | 'fastboot' | 'sideload-auto-reboot';
 
 export default class RebootCommand extends Command<true> {
   async execute(type?: RebootType): Promise<true> {

--- a/src/models/Device.ts
+++ b/src/models/Device.ts
@@ -3,7 +3,7 @@ import { DeviceClient } from "..";
 /**
  * adb device starts
  */
-export type DeviceType = 'emulator' | 'device' | 'offline' | 'unauthorized';
+export type DeviceType = 'emulator' | 'device' | 'offline' | 'unauthorized' | 'recovery';
 
 export default interface Device {
   /**


### PR DESCRIPTION
Android devices that are in recovery mode will show up in ADB as a `recovery` device.

You can tell a device to automatically reboot after a zip file has been sideloaded by running `adb reboot sideload-auto-reboot` instead of `adb reboot sideload`.