### PR TITLE
Add raw metadata to `H264Configuration`

### DIFF
--- a/src/adb/thirdparty/scrcpy/Scrcpy.ts
+++ b/src/adb/thirdparty/scrcpy/Scrcpy.ts
@@ -509,7 +509,8 @@ export default class Scrcpy extends EventEmitter {
 
             const videoConf: H264Configuration = {
               profileIndex, constraintSet, levelIndex, encodedWidth, encodedHeight,
-              cropLeft, cropRight, cropTop, cropBottom, croppedWidth, croppedHeight
+              cropLeft, cropRight, cropTop, cropBottom, croppedWidth, croppedHeight,
+              data: streamChunk
             };
             this.lastConf = videoConf;
             this.emit('config', videoConf);

--- a/src/adb/thirdparty/scrcpy/ScrcpyModels.ts
+++ b/src/adb/thirdparty/scrcpy/ScrcpyModels.ts
@@ -84,6 +84,8 @@ export interface H264Configuration {
 
     croppedWidth: number;
     croppedHeight: number;
+
+    data: Uint8Array;
 }
 
 


### PR DESCRIPTION
Related issue: https://github.com/UrielCh/adbkit/issues/17

Previously, the `H264Configuration` returned in `config` event did not include the raw data for the h264 encoding metadata, which was causing failures in ffmpeg decoding. 

This commit introduces a `data` field in the `H264Configuration`, which is populated during the `config` event with encoding metadata. Now ffmpeg can correctly process the h264 stream.





