### PR TITLE
Ignore incomplete device info when retrieving devices with paths

### DIFF
--- a/src/models/Device.ts
+++ b/src/models/Device.ts
@@ -1,9 +1,13 @@
 import { DeviceClient } from "..";
 
+const deviceTypes = ['emulator', 'device', 'offline', 'unauthorized', 'recovery'] as const;
 /**
  * adb device starts
  */
-export type DeviceType = 'emulator' | 'device' | 'offline' | 'unauthorized' | 'recovery';
+export type DeviceType = typeof deviceTypes[number];
+export function isDeviceType(value: string): value is DeviceType {
+  return deviceTypes.includes(value as DeviceType);
+}
 
 export default interface Device {
   /**


### PR DESCRIPTION
**Problem**

Users can retrieve a list of devices using `client.listDevicesWithPaths()`. Internally, this method parses ADB output which it assumes to be of the form:

```
deafbeef1234     device usb:2-1 product:hero2ltexx model:SM_G935F device:hero2lte transport_id:35
deafbeef4321     device usb:2-2 product:hero2ltexx model:SM_G935F device:hero2lte transport_id:35
```

If `client.listDevicesWithPaths()` is called immediately after a new device is connected, that device may be in `authorizing` state which will cause an exception because it takes the form:

```
deadbeef5432       authorizing usb:1-1.3 transport_id:45
```

**Solution**

Update the string parsing logic to ignore unsupported data.

