### PR TITLE
Don't close connection after A_OPEN in tcp handling

### DIFF
--- a/src/adb/tcpusb/socket.ts
+++ b/src/adb/tcpusb/socket.ts
@@ -235,7 +235,10 @@ export default class Socket extends EventEmitter {
       debug(`Handling ${this.services.count} services simultaneously`);
       return service.handle(packet);
     })
-      .catch(() => true)
+      .catch((err) => {
+        debug(`Got error handling service ${service}. ${err}`)
+        return true;
+      })
       .finally(() => {
         this.services.remove(localId);
         debug(`Handling ${this.services.count} services simultaneously`);


### PR DESCRIPTION
This fixes the tcp server created by createTcpUsbBridge immediately closing the connection right after opening it.

There was an error in translation when converting from bluebird promises to ecmascript ones.
This finally block
https://github.com/DeviceFarmer/adbkit/blob/master/src/adb/tcpusb/service.ts#L125
will only run after the `this.transport.socket`'s `end` or `error` event, while here
https://github.com/UrielCh/adbkit/blob/master/src/adb/tcpusb/service.ts#L137
the finally block will run after the return statement


While the fix is not 100% accurate, it solves the issue we are facing in https://github.com/vkcom/devicehub